### PR TITLE
Fix crash with some revisions of flightgear.

### DIFF
--- a/Sounds/PC-9M-sound.xml
+++ b/Sounds/PC-9M-sound.xml
@@ -126,6 +126,9 @@
       <mode>in-transit</mode>
       <path>Sounds/gear.wav</path>
       <property>/gear/gear[0]/position-norm</property>
+      <volume>
+	<factor>1</factor>
+      </volume>
       <pitch>
         <internal>dt_play</internal>
         <offset>1.0</offset>


### PR DESCRIPTION
When I updated flightgear, from next, end of May 2016, it started crashing on
gear retraction.  Apparently the problem is sounds that have fewer `<volume>`
than `<pitch>` attributes.

I think it should actually use `<property>sim/sound/cabin</property>`, but that
property is not actually set at runtime (which means the engine sound is not
affected by opening and closing the canopy either).
